### PR TITLE
Fix the issue of using '_flinalg' in NFINDR

### DIFF
--- a/pysptools/eea/nfindr.py
+++ b/pysptools/eea/nfindr.py
@@ -103,7 +103,7 @@ def NFINDR(data, q, transform=None, maxit=None, ATGP_init=False):
         for k in range(q):
             for i in range(nsamples):
                 TestMatrix[1:q, k] = transform[i]
-                volume = math.fabs(sp.linalg._flinalg.sdet_c(TestMatrix)[0])
+                volume = math.fabs(sp.linalg.det(TestMatrix)[0])
                 if volume > actualVolume:
                     actualVolume = volume
                     IDX[k] = i


### PR DESCRIPTION
Fixes #14

From scipy 13.0 on, `sp.linalg._flinalg` is not available.
Which is fine, because it's not meant to be used directly:)

This pull request replaces `sp.linalg._flinalg` determinant function with `sp.linalg.det` to fix error. Might become a slower, I haven't checked the performance.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ctherien/pysptools/pull/15?shareId=1b78bfc5-7fb7-4b79-a182-e182fa7dbf01).